### PR TITLE
Implement optimization for zeroing head pattern

### DIFF
--- a/bfjit.c
+++ b/bfjit.c
@@ -330,7 +330,8 @@ defer:
     return result;
 }
 
-bool try_generate_optimized_op(Token_Kind current, Lexer *l, Ops *ops) {
+bool try_generate_optimized_op(Token_Kind current, Lexer *l, Ops *ops)
+{
     Token_Kind tokens[3] = { current };
     if (lexer_peek(l, tokens + 1, 2)) {
         if (tokens[0] == TOK_JUMP_IF_ZERO &&


### PR DESCRIPTION
I feel that it is possible to improve the `Tok_Kind` and `Op_Kind` types, as they are quite similar (perhaps a conversion function, which produces an error if the `Tok_Kind`/char is an optimization sequence (ex. \x1), as these should never (?) be found in the source files. 